### PR TITLE
Expose primary media leaf URL resolution APIs

### DIFF
--- a/Sources/OpenFCPXMLKit/Parsing/FCPXMLResourcesParsing.swift
+++ b/Sources/OpenFCPXMLKit/Parsing/FCPXMLResourcesParsing.swift
@@ -365,9 +365,13 @@ extension OFKXMLElement {
     /// - `ref-clip`: first spine story element inside the compound `media` sequence that
     ///   resolves to a file URL (skips titles/generators without media)
     ///
+    /// This resolves one primary media leaf; it does not enumerate every file in a compound.
+    /// A returned URL does not prove Project usage, filesystem existence, or path authority.
+    /// Title- or generator-only content may return `nil`.
+    ///
     /// - Parameter preferAudioAngle: When `true` on an `mc-clip`, prefer the active audio
     ///   angle’s leaf file (Role Inventory audio-component rows). Default is the video angle.
-    func fcpMediaURL(
+    public func fcpMediaURL(
         in resources: (any OFKXMLElement)? = nil,
         preferAudioAngle: Bool = false
     ) -> URL? {
@@ -382,7 +386,10 @@ extension OFKXMLElement {
     ///
     /// Same host unfold as ``fcpMediaURL(in:preferAudioAngle:)``. Returns `nil` when that
     /// representation is not declared on the resolved leaf asset.
-    func fcpMediaURL(
+    /// This resolves one primary leaf rather than enumerating every media leaf, and does not
+    /// prove Project usage, filesystem existence, or path authority. Title- or generator-only
+    /// content may return `nil`.
+    public func fcpMediaURL(
         in resources: (any OFKXMLElement)? = nil,
         kind: FinalCutPro.FCPXML.MediaRep.Kind,
         preferAudioAngle: Bool = false
@@ -402,7 +409,10 @@ extension OFKXMLElement {
     /// Both values come from one unfold so Role Inventory screenshots can prefer
     /// original and fall back to proxy without resolving a different leaf than
     /// Source File Path.
-    func fcpMediaRepresentationURLs(
+    /// The pair belongs to one primary resolved leaf; it is not an enumeration of all files
+    /// in a compound. The result does not prove Project usage, filesystem existence, or path
+    /// authority. Title- or generator-only content may return `(nil, nil)`.
+    public func fcpMediaRepresentationURLs(
         in resources: (any OFKXMLElement)? = nil,
         preferAudioAngle: Bool = false
     ) -> (original: URL?, proxy: URL?) {

--- a/Tests/OpenFCPXMLKitTests/FCPXMLPublicMediaLeafAPITests.swift
+++ b/Tests/OpenFCPXMLKitTests/FCPXMLPublicMediaLeafAPITests.swift
@@ -1,0 +1,23 @@
+//
+//  FCPXMLPublicMediaLeafAPITests.swift
+//  OpenFCPXMLKit • https://github.com/TheAcharya/OpenFCPXMLKit
+//  © 2026 • Licensed under MIT License
+//
+
+import OpenFCPXMLKit
+import Testing
+
+@Suite("Public primary media leaf API")
+struct FCPXMLPublicMediaLeafAPITests {
+    @Test("External clients can call all primary media leaf APIs")
+    func publicAccessCompilesWithoutTestableImport() {
+        let element = FinalCutPro.FCPXML.AssetClip().element
+
+        #expect(element.fcpMediaURL() == nil)
+        #expect(element.fcpMediaURL(kind: .originalMedia) == nil)
+
+        let representations = element.fcpMediaRepresentationURLs()
+        #expect(representations.original == nil)
+        #expect(representations.proxy == nil)
+    }
+}


### PR DESCRIPTION
## Summary

- Exposes three existing, internally used primary media leaf URL resolution methods without changing their behavior or algorithms.
- Returns one primary leaf original/proxy pair; it does not enumerate all media leaves.
- Does not assert Project usage, filesystem existence, or URL authority.
- Adds a public-import compile test to prevent access-level regressions.